### PR TITLE
NETOBSERV-1466 rely on duplicate different than 'true' for prom queries

### DIFF
--- a/apis/flowmetrics/v1alpha1/flowmetric_types.go
+++ b/apis/flowmetrics/v1alpha1/flowmetric_types.go
@@ -29,13 +29,14 @@ const (
 	HistogramMetric MetricType = "Histogram"
 	// Note: we don't expose gauge on purpose to avoid configuration mistake related to gauge limitation.
 	// 99% of times, "counter" or "histogram" should be the ones to use. We can eventually revisit later.
-	MatchExact    FilterMatchType = "Exact"
-	MatchRegex    FilterMatchType = "Regex"
-	MatchPresence FilterMatchType = "Presence"
-	MatchAbsence  FilterMatchType = "Absence"
-	Egress        NodeDirection   = "Egress"
-	Ingress       NodeDirection   = "Ingress"
-	AnyDirection  NodeDirection   = "Any"
+	MatchExact     FilterMatchType = "Exact"
+	MatchDifferent FilterMatchType = "Different"
+	MatchRegex     FilterMatchType = "Regex"
+	MatchPresence  FilterMatchType = "Presence"
+	MatchAbsence   FilterMatchType = "Absence"
+	Egress         NodeDirection   = "Egress"
+	Ingress        NodeDirection   = "Ingress"
+	AnyDirection   NodeDirection   = "Any"
 )
 
 type MetricFilter struct {
@@ -48,7 +49,7 @@ type MetricFilter struct {
 	Value string `json:"value"`
 
 	// Type of matching to apply
-	// +kubebuilder:validation:Enum:="Exact";"Regex";"Presence";"Absence"
+	// +kubebuilder:validation:Enum:="Exact";"Different";"Regex";"Presence";"Absence"
 	// +kubebuilder:default:="Exact"
 	MatchType FilterMatchType `json:"matchType"`
 }
@@ -77,7 +78,7 @@ type FlowMetricSpec struct {
 	ValueField string `json:"valueField,omitempty"`
 
 	// `filters` is a list of fields and values used to restrict which flows are taken into account. Oftentimes, these filters must
-	// be used to eliminate duplicates: `Duplicate:"false"` and `NodeDirection: "0"`.
+	// be used to eliminate duplicates: `Duplicate != "true"` and `NodeDirection = "0"`.
 	// Refer to the documentation for the list of available fields: https://docs.openshift.com/container-platform/latest/networking/network_observability/json-flows-format-reference.html.
 	// +optional
 	Filters []MetricFilter `json:"filters"`
@@ -92,7 +93,7 @@ type FlowMetricSpec struct {
 	Labels []string `json:"labels"`
 
 	// When set to `true`, flows duplicated across several interfaces will add up in the generated metrics.
-	// When set to `false` (default), it is equivalent to adding the exact filter on `Duplicate`: `false`.
+	// When set to `false` (default), it is equivalent to adding the exact filter on `Duplicate` != `true`.
 	// +optional
 	IncludeDuplicates bool `json:"includeDuplicates,omitempty"`
 

--- a/bundle/manifests/flows.netobserv.io_flowmetrics.yaml
+++ b/bundle/manifests/flows.netobserv.io_flowmetrics.yaml
@@ -61,8 +61,8 @@ spec:
               filters:
                 description: '`filters` is a list of fields and values used to restrict
                   which flows are taken into account. Oftentimes, these filters must
-                  be used to eliminate duplicates: `Duplicate:"false"` and `NodeDirection:
-                  "0"`. Refer to the documentation for the list of available fields:
+                  be used to eliminate duplicates: `Duplicate != "true"` and `NodeDirection
+                  = "0"`. Refer to the documentation for the list of available fields:
                   https://docs.openshift.com/container-platform/latest/networking/network_observability/json-flows-format-reference.html.'
                 items:
                   properties:
@@ -74,6 +74,7 @@ spec:
                       description: Type of matching to apply
                       enum:
                       - Exact
+                      - Different
                       - Regex
                       - Presence
                       - Absence
@@ -87,10 +88,9 @@ spec:
                   type: object
                 type: array
               includeDuplicates:
-                description: 'When set to `true`, flows duplicated across several
-                  interfaces will add up in the generated metrics. When set to `false`
-                  (default), it is equivalent to adding the exact filter on `Duplicate`:
-                  `false`.'
+                description: When set to `true`, flows duplicated across several interfaces
+                  will add up in the generated metrics. When set to `false` (default),
+                  it is equivalent to adding the exact filter on `Duplicate` != `true`.
                 type: boolean
               labels:
                 description: '`labels` is a list of fields that should be used as

--- a/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/netobserv-operator.clusterserviceversion.yaml
@@ -26,7 +26,8 @@ metadata:
               },
               {
                 "field": "Duplicate",
-                "value": "false"
+                "matchType": "Different",
+                "value": "true"
               },
               {
                 "field": "NodeDirection",

--- a/config/crd/bases/flows.netobserv.io_flowmetrics.yaml
+++ b/config/crd/bases/flows.netobserv.io_flowmetrics.yaml
@@ -63,8 +63,8 @@ spec:
               filters:
                 description: '`filters` is a list of fields and values used to restrict
                   which flows are taken into account. Oftentimes, these filters must
-                  be used to eliminate duplicates: `Duplicate:"false"` and `NodeDirection:
-                  "0"`. Refer to the documentation for the list of available fields:
+                  be used to eliminate duplicates: `Duplicate != "true"` and `NodeDirection
+                  = "0"`. Refer to the documentation for the list of available fields:
                   https://docs.openshift.com/container-platform/latest/networking/network_observability/json-flows-format-reference.html.'
                 items:
                   properties:
@@ -76,6 +76,7 @@ spec:
                       description: Type of matching to apply
                       enum:
                       - Exact
+                      - Different
                       - Regex
                       - Presence
                       - Absence
@@ -89,10 +90,9 @@ spec:
                   type: object
                 type: array
               includeDuplicates:
-                description: 'When set to `true`, flows duplicated across several
-                  interfaces will add up in the generated metrics. When set to `false`
-                  (default), it is equivalent to adding the exact filter on `Duplicate`:
-                  `false`.'
+                description: When set to `true`, flows duplicated across several interfaces
+                  will add up in the generated metrics. When set to `false` (default),
+                  it is equivalent to adding the exact filter on `Duplicate` != `true`.
                 type: boolean
               labels:
                 description: '`labels` is a list of fields that should be used as

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,7 +14,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/netobserv/network-observability-operator
-  newTag: 1.0.5
+  newName: quay.io/jpinsonn/network-observability-operator
+  newTag: 1466-nodedir-4
 commonLabels:
   app: netobserv-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,11 +31,11 @@ spec:
         - --profiling-bind-address=$(PROFILING_BIND_ADDRESS)
         env:
           - name: RELATED_IMAGE_EBPF_AGENT
-            value: quay.io/netobserv/netobserv-ebpf-agent:v0.3.3
+            value: quay.io/netobserv/netobserv-ebpf-agent:main
           - name: RELATED_IMAGE_FLOWLOGS_PIPELINE
-            value: quay.io/netobserv/flowlogs-pipeline:v0.1.11
+            value: quay.io/netobserv/flowlogs-pipeline:main
           - name: RELATED_IMAGE_CONSOLE_PLUGIN
-            value: quay.io/netobserv/network-observability-console-plugin:v0.1.12
+            value: quay.io/netobserv/network-observability-console-plugin:main
           - name: DOWNSTREAM_DEPLOYMENT
             value: "false"
           - name: PROFILING_BIND_ADDRESS

--- a/config/samples/flows_v1alpha1_flowmetric.yaml
+++ b/config/samples/flows_v1alpha1_flowmetric.yaml
@@ -19,7 +19,8 @@ spec:
     value: "^\\d\\d?\\d?\\d?$"
     matchType: Regex
   - field: Duplicate
-    value: "false"
+    value: "true"
+    matchType: Different
   - field: NodeDirection
     value: "1|2"
     matchType: Regex

--- a/controllers/flp/flp_pipeline_builder.go
+++ b/controllers/flp/flp_pipeline_builder.go
@@ -190,7 +190,7 @@ func flowMetricToFLP(flowMetric *metricslatest.FlowMetricSpec) (*api.MetricsItem
 		m.Filters = append(m.Filters, api.MetricsFilter{Key: f.Field, Value: f.Value, Type: strings.ToLower(string(f.MatchType))})
 	}
 	if !flowMetric.IncludeDuplicates {
-		m.Filters = append(m.Filters, api.MetricsFilter{Key: "Duplicate", Value: "false", Type: "exact"})
+		m.Filters = append(m.Filters, api.MetricsFilter{Key: "Duplicate", Value: "true", Type: "different"})
 	}
 	if flowMetric.Direction == metricslatest.Egress {
 		m.Filters = append(m.Filters, api.MetricsFilter{Key: "NodeDirection", Value: "1|2", Type: "regex"})

--- a/controllers/flp/metrics_api_test.go
+++ b/controllers/flp/metrics_api_test.go
@@ -93,7 +93,7 @@ func TestFlowMetricToFLP(t *testing.T) {
 		Filter: api.MetricsFilter{Key: "", Value: "", Type: ""},
 		Filters: []api.MetricsFilter{
 			{Key: "f", Value: "v", Type: api.PromFilterExact},
-			{Key: "Duplicate", Value: "false", Type: api.PromFilterExact},
+			{Key: "Duplicate", Value: "true", Type: api.PromFilterDifferent},
 		},
 		ValueKey: "val",
 		Labels:   []string{"by_field"},

--- a/pkg/metrics/predefined_metrics.go
+++ b/pkg/metrics/predefined_metrics.go
@@ -69,7 +69,7 @@ func init() {
 						Type:     "counter",
 						ValueKey: valueField,
 						Filters: []flpapi.MetricsFilter{
-							{Key: "Duplicate", Value: "false"},
+							{Key: "Duplicate", Value: "true", Type: flpapi.PromFilterDifferent},
 							{Key: "NodeDirection", Value: mapDirection[dir], Type: flpapi.PromFilterRegex},
 						},
 						Labels: labels,
@@ -108,7 +108,7 @@ func init() {
 				Type:     "counter",
 				ValueKey: "PktDropPackets",
 				Filters: []flpapi.MetricsFilter{
-					{Key: "Duplicate", Value: "false"},
+					{Key: "Duplicate", Value: "true", Type: flpapi.PromFilterDifferent},
 					{Key: "PktDropPackets", Type: flpapi.PromFilterPresence},
 				},
 				Labels: labels,
@@ -121,7 +121,7 @@ func init() {
 				Type:     "counter",
 				ValueKey: "PktDropBytes",
 				Filters: []flpapi.MetricsFilter{
-					{Key: "Duplicate", Value: "false"},
+					{Key: "Duplicate", Value: "true", Type: flpapi.PromFilterDifferent},
 					{Key: "PktDropBytes", Type: flpapi.PromFilterPresence},
 				},
 				Labels: labels,

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/api/api.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/api/api.go
@@ -51,6 +51,7 @@ const (
 	AddKubernetesInfraRuleType   = "add_kubernetes_infra"
 	ReinterpretDirectionRuleType = "reinterpret_direction"
 	PromFilterExact              = "exact"
+	PromFilterDifferent          = "different"
 	PromFilterPresence           = "presence"
 	PromFilterAbsence            = "absence"
 	PromFilterRegex              = "regex"

--- a/vendor/github.com/netobserv/flowlogs-pipeline/pkg/api/encode_prom.go
+++ b/vendor/github.com/netobserv/flowlogs-pipeline/pkg/api/encode_prom.go
@@ -70,14 +70,15 @@ type MetricsItems []MetricsItem
 type MetricsFilter struct {
 	Key   string `yaml:"key" json:"key" doc:"the key to match and filter by"`
 	Value string `yaml:"value" json:"value" doc:"the value to match and filter by"`
-	Type  string `yaml:"type" json:"type" enum:"MetricEncodeFilterTypeEnum" doc:"the type of filter match: exact (default), presence, absence or regex"`
+	Type  string `yaml:"type" json:"type" enum:"MetricEncodeFilterTypeEnum" doc:"the type of filter match: exact (default), different, presence, absence or regex"`
 }
 
 type MetricEncodeFilterTypeEnum struct {
-	Exact    string `yaml:"exact" json:"exact" doc:"match exactly the provided fitler value"`
-	Presence string `yaml:"presence" json:"presence" doc:"filter key must be present (filter value is ignored)"`
-	Absence  string `yaml:"absence" json:"absence" doc:"filter key must be absent (filter value is ignored)"`
-	Regex    string `yaml:"regex" json:"regex" doc:"match filter value as a regular expression"`
+	Exact     string `yaml:"exact" json:"exact" doc:"match exactly the provided fitler value"`
+	Different string `yaml:"different" json:"different" doc:"not match the provided fitler value"`
+	Presence  string `yaml:"presence" json:"presence" doc:"filter key must be present (filter value is ignored)"`
+	Absence   string `yaml:"absence" json:"absence" doc:"filter key must be absent (filter value is ignored)"`
+	Regex     string `yaml:"regex" json:"regex" doc:"match filter value as a regular expression"`
 }
 
 func MetricEncodeFilterTypeName(t string) string {


### PR DESCRIPTION
## Description

Use `different` filter for prometheus metrics to allow queries to work whatever eBPF merge mode is used.

## Dependencies

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
